### PR TITLE
[#24] 검색뷰 구현 (with dummy data)

### DIFF
--- a/Spon-us.xcodeproj/project.pbxproj
+++ b/Spon-us.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		100D38B82B4EF54100498977 /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100D38B72B4EF54100498977 /* CategoryView.swift */; };
 		100D38BA2B4EF54C00498977 /* MyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100D38B92B4EF54C00498977 /* MyView.swift */; };
 		3B2021772B4C56000010CA02 /* ProposalReceivedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2021762B4C56000010CA02 /* ProposalReceivedListView.swift */; };
+		807BF83F2B51BCD400A659B9 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807BF83E2B51BCD400A659B9 /* SearchView.swift */; };
 		DF91F4042B4864330021291A /* Portfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF91F4032B4864330021291A /* Portfolio.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +42,7 @@
 		100D38B72B4EF54100498977 /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
 		100D38B92B4EF54C00498977 /* MyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyView.swift; sourceTree = "<group>"; };
 		3B2021762B4C56000010CA02 /* ProposalReceivedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalReceivedListView.swift; sourceTree = "<group>"; };
+		807BF83E2B51BCD400A659B9 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		DF91F4032B4864330021291A /* Portfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Portfolio.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -115,6 +117,7 @@
 				100D38B52B4EF51E00498977 /* SavedView.swift */,
 				100D38B72B4EF54100498977 /* CategoryView.swift */,
 				100D38B92B4EF54C00498977 /* MyView.swift */,
+				807BF83E2B51BCD400A659B9 /* SearchView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -200,6 +203,7 @@
 				100D38B82B4EF54100498977 /* CategoryView.swift in Sources */,
 				100D38B32B4EF15600498977 /* HomeView.swift in Sources */,
 				100D38B12B44852700498977 /* ContentView.swift in Sources */,
+				807BF83F2B51BCD400A659B9 /* SearchView.swift in Sources */,
 				100D38A72B44836800498977 /* Spon_usApp.swift in Sources */,
 				3B2021772B4C56000010CA02 /* ProposalReceivedListView.swift in Sources */,
 			);

--- a/Spon-us/View/HomeView.swift
+++ b/Spon-us/View/HomeView.swift
@@ -26,9 +26,9 @@ struct HomeView: View {
     @State private var progressStatus  = Portfolio.ProgressStatus()
     
     let searchItem: some View = {
-        Button(action: {
-            
-        }) {
+        NavigationLink {
+            SearchView()
+        } label: {
             Image("ic_search")
         }
     }()

--- a/Spon-us/View/SearchView.swift
+++ b/Spon-us/View/SearchView.swift
@@ -1,0 +1,170 @@
+//
+//  SearchView.swift
+//  Spon-us
+//
+//  Created by 김수민 on 1/13/24.
+//
+
+import SwiftUI
+
+struct SearchView: View {
+    @State var searchData: String = ""
+    var dummyData1: Array<String> = ["무신사 글로벌 마케팅 연계 프로젝트", "무신사 오프라인 스토어 홍보 방안", "무신사 앰버서더 선정 프로젝트"]
+    var dummyData2: Array<String> = ["무신사", "패션/IT"]
+    var dummyData3: Array<String> = ["무신사협업", "코카콜라", "해커스", "바른안과", "대학생제휴", "연계", "무신사", "노티드"]
+    
+    var body: some View {
+        VStack(spacing: 0){
+            SponUsDivider().frame(width: 335)
+                .foregroundColor(searchData=="" ? .sponusBlack : .sponusPrimary)
+                .padding(.bottom, 48)
+                .padding(.top, 15)
+            
+            if (searchData == ""){
+                VStack(alignment: .leading, spacing: 36){
+                    VStack(alignment: .leading, spacing: 16){
+                        HStack(){
+                            Text("최근 검색어").font(.Body01)
+                            Spacer()
+                        }
+                        VStack(spacing: 8){
+                            HStack(spacing: 8){
+                                ForEach(0..<3, id: \.self){index in
+                                    SearchCategoryButton(content: dummyData3[index], isDelete: true)
+                                }
+                                Spacer()
+                            }
+                            HStack(spacing: 8){
+                                ForEach(0..<3, id: \.self){index in
+                                    SearchCategoryButton(content: dummyData3[3+index], isDelete: true)
+                                }
+                                Spacer()
+                            }
+                            HStack(spacing: 8){
+                                ForEach(0..<2, id: \.self){index in
+                                    SearchCategoryButton(content: dummyData3[6+index], isDelete: true)
+                                }
+                                Spacer()
+                            }
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 16){
+                        Text("스포너스 추천 검색어").font(.Body01)
+                        HStack(spacing: 8){
+                            SearchCategoryButton(content: "마케팅", isDelete: false)
+                            SearchCategoryButton(content: "디자인", isDelete: false)
+                            SearchCategoryButton(content: "연계 프로젝트", isDelete: false)
+                        }
+                    }
+                }.padding(.horizontal, 20)
+            } else {
+                VStack(alignment: .leading, spacing: 16){
+                    HStack(){
+                        Text("공고 정보").font(.Body06)
+                        Spacer()
+                    }
+                    ForEach(0..<3, id: \.self){ index in
+                        HStack(spacing: 0) {
+                            ForEach(splitText(dummyData1[index], with: searchData), id: \.self) { text in
+                                Text(text)
+                                    .foregroundColor(text == searchData ? .sponusPrimary : .sponusGrey800).font(.Body05)
+                            }
+                        }
+                        SponUsDivider().foregroundColor(.sponusGrey100)
+                    }
+                    Text("기업 정보").font(.Body06)
+                    HStack(spacing: 12){
+                        Image("company_dummy").frame(width: 46, height: 46)
+                        VStack(spacing: 1){
+                            HStack(spacing: 0) {
+                                ForEach(splitText(dummyData2[0], with: searchData), id: \.self) { text in
+                                    Text(text)
+                                        .foregroundColor(text == searchData ? .sponusPrimary : .sponusGrey800).font(.Body05)
+                                }
+                            }
+                            Text(dummyData2[1]).foregroundColor(.sponusGrey700).font(.Body10)
+                        }
+                    }
+                }.padding(.horizontal, 20)
+            }
+            Spacer()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: SearchBarView(searchData: $searchData))
+    }
+    func splitText(_ text: String, with keyword: String) -> [String] {
+        var parts: [String] = []
+        let components = text.components(separatedBy: keyword)
+        for (index, component) in components.enumerated() {
+            if !component.isEmpty {
+                parts.append(component)
+            }
+            if index < components.count - 1 {
+                parts.append(keyword)
+            }
+        }
+        return parts
+    }
+}
+struct SearchBarView: View {
+    @Binding var searchData: String
+    var body: some View {
+        HStack(spacing: 24){
+            CustomBackButton()
+            TextField("검색어를 입력하세요", text: $searchData)
+                .textFieldStyle(SearchTextfieldStyle())
+                .frame(height: 26)
+                .onChange(of: searchData) { newData in
+                    searchData = newData
+                }
+            Spacer()
+            Image("ic_search")
+        }
+        .padding(.leading, 16)
+        .padding(.trailing, 20)
+        .padding(.vertical, 19)
+    }
+}
+struct SponUsDivider: View {
+    var body: some View {
+        Rectangle()
+            .frame(maxWidth: .infinity, maxHeight: 1)
+    }
+}
+
+
+struct SearchTextfieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+            configuration
+                .font(.Body04)
+                .padding(16)
+    }
+}
+
+struct SearchCategoryButton: View {
+    let content: String
+    let isDelete: Bool
+    var body: some View {
+        HStack(){
+            Text(content).font(.Body08).foregroundColor(.sponusBlack)
+            if isDelete {
+                Button(action: {}){
+                    Image("ic_cancel").frame(width: 16, height: 16)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(height: 40)
+        .overlay(
+            RoundedRectangle(cornerRadius: 99)
+                .stroke(.sponusGrey500)
+        )
+    }
+}
+
+#Preview {
+    SearchView()
+}


### PR DESCRIPTION
검색뷰 구현했습니다.
## 💡 논의할 점 | Q&A
- [ ] textfield에 입력할 때 한국어가 자음모음이 분리가 되는데 찾아보니 iOS 16이하까지 한국어 지원이 된다는데 ,, target 버전을 낮춰보니 코드에서 iOS 17부터 써야하는 함수들이 있어 충돌이 일어납니다. 현재 시뮬레이터 영상은 무신사를 복사/붙어넣기를 한 상황입니다.
- [ ] searchbar를 커스텀으로 만들었는데 navigationbar item에 들어가니 디자인과 똑같이 나오지 않은데 해결이 잘 안되네요 ..

## 시뮬레이터

https://github.com/spon-us/SponUs-iOS/assets/125457422/cd9d6129-bc4b-4133-9783-998cdeabd3cb

