### PR TITLE
[#63] 마이페이지 / 담당자 정보 수정하기 구현

### DIFF
--- a/Spon-us.xcodeproj/project.pbxproj
+++ b/Spon-us.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		109F9E2A2B6E7536006B7D63 /* CouponView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109F9E292B6E7536006B7D63 /* CouponView.swift */; };
 		10C8AC612B5C340D00B40547 /* SendOfferPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C8AC602B5C340D00B40547 /* SendOfferPostView.swift */; };
 		10C8AC632B5C34C400B40547 /* CompanyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C8AC622B5C34C400B40547 /* CompanyPostView.swift */; };
+		10EBD80D2B6F783F0082CD8E /* HonorInfoEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EBD80C2B6F783F0082CD8E /* HonorInfoEditView.swift */; };
 		3B2021772B4C56000010CA02 /* ProposalReceivedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2021762B4C56000010CA02 /* ProposalReceivedListView.swift */; };
 		3B81BCB22B622EBF0067E9CB /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B81BCB12B622EBF0067E9CB /* StoreKitManager.swift */; };
 		3B81BCB42B622ED00067E9CB /* StoreKitTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B81BCB32B622ED00067E9CB /* StoreKitTestView.swift */; };
@@ -79,6 +80,7 @@
 		10C8AC602B5C340D00B40547 /* SendOfferPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendOfferPostView.swift; sourceTree = "<group>"; };
 		10C8AC622B5C34C400B40547 /* CompanyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyPostView.swift; sourceTree = "<group>"; };
 		10C8AC642B5EA69B00B40547 /* ChargerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargerInfoView.swift; sourceTree = "<group>"; };
+		10EBD80C2B6F783F0082CD8E /* HonorInfoEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HonorInfoEditView.swift; sourceTree = "<group>"; };
 		3B2021762B4C56000010CA02 /* ProposalReceivedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalReceivedListView.swift; sourceTree = "<group>"; };
 		3B81BCB12B622EBF0067E9CB /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
 		3B81BCB32B622ED00067E9CB /* StoreKitTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitTestView.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 				100D38B92B4EF54C00498977 /* MyView.swift */,
 				109F9E272B6E692B006B7D63 /* MyTermsView.swift */,
 				109F9E292B6E7536006B7D63 /* CouponView.swift */,
+				10EBD80C2B6F783F0082CD8E /* HonorInfoEditView.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				DF90A5B62B6B7CF900BC54D0 /* RegisterIDView.swift in Sources */,
 				100D38B12B44852700498977 /* ContentView.swift in Sources */,
 				DF90A5B02B664E9600BC54D0 /* GatherAndUsageView.swift in Sources */,
+				10EBD80D2B6F783F0082CD8E /* HonorInfoEditView.swift in Sources */,
 				106720022B5835FA00493354 /* SendOfferView.swift in Sources */,
 				3B81BCBC2B622F750067E9CB /* PaymentView.swift in Sources */,
 				3B81BCB22B622EBF0067E9CB /* StoreKitManager.swift in Sources */,

--- a/Spon-us/View/MyPage/CouponView.swift
+++ b/Spon-us/View/MyPage/CouponView.swift
@@ -81,7 +81,6 @@ struct CouponView: View {
         Text("쿠폰이 등록 되었습니다")
             .font(.Body03)
             .foregroundStyle(.sponusPrimary)
-            .padding(.leading, 20)
             .frame(height: 56)
             .frame(maxWidth: .infinity)
             .background(Color.sponusSecondary)

--- a/Spon-us/View/MyPage/HonorInfoEditView.swift
+++ b/Spon-us/View/MyPage/HonorInfoEditView.swift
@@ -1,0 +1,242 @@
+//
+//  HonorInfoEditView.swift
+//  Spon-us
+//
+//  Created by yubin on 2/4/24.
+//
+
+import SwiftUI
+
+struct HonorInfoEditView: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    @State private var email: String = ""
+    @State private var phone: String = ""
+    @State private var time: String = ""
+    @State private var selectedDays: Set<String> = []
+    @State private var selectedContact: Set<String> = []
+    @State var showingInfoPopup = false
+    
+    let daysOfWeek = ["월", "화", "수", "목", "금", "토", "일"]
+    let contact = ["이메일", "전화", "zoom", "대면 미팅"]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                Text("협력 성사 시에 보이게 될\n컨택 담당자의 정보를 등록합니다.")
+                    .font(.Body10)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color.sponusBlack)
+                    .frame(height: 82)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.sponusGrey50)
+                    .padding(.top, 16)
+                    .padding(.bottom, 28)
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("연락처")
+                        .font(.Heading09)
+                        .foregroundColor(Color.sponusBlack)
+                    
+                    Rectangle()
+                        .fill(Color.sponusBlack)
+                        .frame(maxWidth: .infinity, maxHeight: 1)
+                        .padding(.top, 16)
+                    
+                    HStack {
+                        Text("e-mail")
+                            .font(.English08)
+                            .foregroundColor(Color.sponusGrey800)
+                            .padding(.trailing, 17)
+                        
+                        
+                        TextField("", text: $email, prompt: Text(verbatim: "ex.sponus@gmail.com"))
+                            .font(.English08)
+                            .padding(.leading, 20)
+                            .foregroundColor(Color.sponusBlack)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .overlay(
+                                Rectangle()
+                                    .inset(by: 0.5)
+                                    .stroke(Color.sponusGrey100, lineWidth: 1)
+                            )
+                    }
+                    .padding(.top, 24)
+                    
+                    HStack {
+                        Text("phone")
+                            .font(.English08)
+                            .foregroundColor(Color.sponusGrey800)
+                            .padding(.trailing, 20)
+                        
+                        
+                        TextField("", text: $phone, prompt: Text(verbatim: "ex.010-1234-5671"))
+                            .font(.English08)
+                            .padding(.leading, 20)
+                            .foregroundColor(Color.sponusBlack)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .overlay(
+                                Rectangle()
+                                    .inset(by: 0.5)
+                                    .stroke(Color.sponusGrey100, lineWidth: 1)
+                            )
+                    }
+                    .padding(.top, 16)
+                }
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("연락 가능 시간")
+                        .font(.Heading09)
+                        .foregroundColor(Color.sponusBlack)
+                        .padding(.top, 32)
+                    
+                    Rectangle()
+                        .fill(Color.sponusBlack)
+                        .frame(maxWidth: .infinity, maxHeight: 1)
+                        .padding(.top, 16)
+                    
+                    HStack {
+                        Text("day")
+                            .font(.English08)
+                            .foregroundColor(Color.sponusGrey800)
+                            .padding(.trailing, 38)
+                        
+                        ForEach(daysOfWeek, id: \.self) { day in
+                            Button(action: {
+                                selectDay(day)
+                            }) {
+                                Text(day)
+                                    .font(.Body10)
+                                    .foregroundColor(selectedDays.contains(day) ? Color.sponusBlack : Color.sponusGrey600)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 18)
+                                    .overlay(
+                                        Rectangle()
+                                            .stroke(selectedDays.contains(day) ? Color.sponusBlack : Color.sponusGrey100, lineWidth: 1)
+                                    )
+                            }
+                        }
+                    }
+                    .padding(.top, 24)
+                    
+                    HStack {
+                        Text("time")
+                            .font(.English08)
+                            .foregroundColor(Color.sponusGrey800)
+                            .padding(.trailing, 33)
+                        
+                        
+                        TextField("", text: $time, prompt: Text(verbatim: "ex.14:00 - 18:00"))
+                            .font(.English08)
+                            .padding(.leading, 20)
+                            .foregroundColor(Color.sponusBlack)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .overlay(
+                                Rectangle()
+                                    .inset(by: 0.5)
+                                    .stroke(Color.sponusGrey100, lineWidth: 1)
+                            )
+                    }
+                    .padding(.top, 24)
+                }
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("선호 연락 방법")
+                        .font(.Heading09)
+                        .foregroundColor(Color.sponusBlack)
+                        .padding(.top, 32)
+                    
+                    Rectangle()
+                        .fill(Color.sponusBlack)
+                        .frame(maxWidth: .infinity, maxHeight: 1)
+                        .padding(.top, 16)
+                    
+                    HStack {
+                        Text("contact")
+                            .font(.English08)
+                            .foregroundColor(Color.sponusGrey800)
+                            .padding(.trailing, 11)
+                        
+                        ForEach(contact, id: \.self) { contact in
+                            Button(action: {
+                                selectContact(contact)
+                            }) {
+                                Text(contact)
+                                    .font(.Body10)
+                                    .foregroundColor(selectedContact.contains(contact) ? Color.sponusBlack : Color.sponusGrey600)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 18)
+                                    .overlay(
+                                        Rectangle()
+                                            .stroke(selectedContact.contains(contact) ? Color.sponusBlack : Color.sponusGrey100, lineWidth: 1)
+                                    )
+                            }
+                        }
+                    }
+                    .padding(.top, 24)
+                }
+                .padding(.bottom, 52)
+            }
+            .padding(.horizontal, 20)
+            Button {
+                showingInfoPopup = true
+            } label: {
+                Text("확인").font(.Body01)
+                    .foregroundStyle(.sponusPrimaryDarkmode)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 20)
+            }.background(.sponusBlack)
+        }
+        .popup(isPresented: $showingInfoPopup) {
+            registerInfoToastMessage()
+        } customize: {
+            $0.type(.floater(verticalPadding: 56))
+                .position(.bottom)
+                .animation(.spring)
+                .closeOnTap(false)
+                .closeOnTapOutside(true)
+                .autohideIn(2)
+        }
+        .navigationTitle("담당자 정보 수정하기").font(.Body01)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: CustomBackButton())
+        .toolbar(.hidden, for: .tabBar)
+    }
+    
+    func selectDay(_ day: String) {
+        if selectedDays.contains(day) {
+            selectedDays.remove(day)
+        } else {
+            selectedDays.insert(day)
+        }
+    }
+    
+    func selectContact(_ contact: String) {
+        if selectedContact.contains(contact) {
+            selectedContact.remove(contact)
+        } else {
+            selectedContact.insert(contact)
+        }
+    }
+    
+    func registerInfoToastMessage() -> some View {
+        Text("수정이 완료되었습니다")
+            .font(.Body03)
+            .foregroundStyle(.sponusPrimary)
+            .frame(height: 56)
+            .frame(maxWidth: .infinity)
+            .background(Color.sponusSecondary)
+            .onDisappear {
+                presentationMode.wrappedValue.dismiss()
+            }
+            .padding(.horizontal, 20)
+    }
+}
+
+#Preview {
+    HonorInfoEditView()
+}

--- a/Spon-us/View/MyPage/MyView.swift
+++ b/Spon-us/View/MyPage/MyView.swift
@@ -73,7 +73,7 @@ struct MyView: View {
             
             ScrollView {
                 VStack(spacing: 20) {
-                    NavigationLink(destination: EmptyView()) {
+                    NavigationLink(destination: HonorInfoEditView()) {
                         HStack {
                             Text("담당자 정보 수정하기")
                                 .font(.Body05)


### PR DESCRIPTION
## ✅ Task
- 담당자 정보 수정하기 UI 구현


## 🍏 시뮬레이터
| 담당자 정보 수정하기 | 정보 입력 | 수정 완료 |
| ------------ | ------------ | ------------ | 
| ![담당자 정보 수정하기](https://github.com/spon-us/SponUs-iOS/assets/69234788/ecd733d5-4edb-4623-aa96-73f885e591b8) | ![정보 입력](https://github.com/spon-us/SponUs-iOS/assets/69234788/df0ca2a6-1fca-41b7-9c61-2f8fe0cb4599) | ![수정 완료](https://github.com/spon-us/SponUs-iOS/assets/69234788/ec0f2948-8798-4069-8a15-1d80349306c8) |


## 💡 Issue
- 프로필 수정
- 로그아웃 / 계정탈퇴 초기 로그인 화면으로 미연결