### PR TITLE
[#89] 보낸 제안 / 날짜에 따라 Section 구분

### DIFF
--- a/Spon-us/Model/SendOffer/ProposalModel.swift
+++ b/Spon-us/Model/SendOffer/ProposalModel.swift
@@ -14,6 +14,11 @@ struct ProposalModel: Codable {
 }
 
 struct ProposalResponse: Codable, Hashable {
+    let createdDate: String
+    let proposes: [Propose]
+}
+
+struct Propose: Codable, Hashable {
     let proposeId: Int
     let title: String
     let status: String
@@ -21,15 +26,17 @@ struct ProposalResponse: Codable, Hashable {
     let proposedOrganizationName: String
     let proposingOrganizationId: Int
     let proposingOrganizationName: String
+    let isReported: Bool
+    let reportId: Int?
     let announcementSummary: AnnouncementSummary
     let createdDate: String
     let createdDay: String
-    static func == (lhs: ProposalResponse, rhs: ProposalResponse) -> Bool {
-            return lhs.proposeId == rhs.proposeId
-        }
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(proposeId)
-        }
+    static func == (lhs: Propose, rhs: Propose) -> Bool {
+        return lhs.proposeId == rhs.proposeId
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(proposeId)
+    }
 }
 
 struct AnnouncementSummary: Codable {
@@ -44,6 +51,7 @@ struct AnnouncementSummary: Codable {
     let viewCount: Int
     let createdAt: String
     let updatedAt: String
+    let saveCount: Int
 }
 
 struct MainImage: Codable {

--- a/Spon-us/View/ReceivedOffer/ProposalReceivedListView.swift
+++ b/Spon-us/View/ReceivedOffer/ProposalReceivedListView.swift
@@ -76,10 +76,10 @@ struct ProposalReceivedListView: View {
                                     .padding(.trailing, 17)
                                 
                                 VStack(alignment: .leading, spacing: 6) {
-                                    Text(receivedViewModel.proposalReceived[index].proposingOrganizationName)
+                                    Text(receivedViewModel.proposalReceived[index].proposes[index].proposingOrganizationName)
                                         .font(.Body07)
                                     
-                                    Text(receivedViewModel.proposalReceived[index].title)
+                                    Text(receivedViewModel.proposalReceived[index].proposes[index].title)
                                         .font(.Body10)
                                         .foregroundColor(Color.sponusGrey800)
                                 }


### PR DESCRIPTION
## ✅ Task
- API 업데이트에 따른 제안 Model 수정 -> 날짜 기준 그룹핑 내림차순 정렬 fb96f15
- 보낸 제안 / 날짜에 따라 Section 구분 4c93dd3


## 🍏 시뮬레이터
| 정렬된 보낸 제안 |
| ------------ |
| <img width="250px" alt="보낸 제안" src="https://github.com/spon-us/SponUs-iOS/assets/69234788/6d4ee18d-f6d7-4c68-9567-5e1af92204b2"> |


## 💡 Issue
- 디자인 궁금증 생김