### PR TITLE
[#89] 보낸 제안 뷰에서 선택된 proposeId, 보낸 제안서 확인 뷰에 전달하는 로직 수정

### DIFF
--- a/Spon-us/Model/SendOffer/ProposalDetailViewModel.swift
+++ b/Spon-us/Model/SendOffer/ProposalDetailViewModel.swift
@@ -21,6 +21,7 @@ class ProposalDetailViewModel: ObservableObject {
                 do {
                     let proposalDetailResponse = try response.map(ProposalDetailModel.self)
                     self.proposalDetail = proposalDetailResponse.content
+                    //print("넘어온 Propose ID: \(proposeId)")
                 } catch {
                     print("Error parsing response: \(error)")
                 }

--- a/Spon-us/View/SendOffer/SendOfferPostView.swift
+++ b/Spon-us/View/SendOffer/SendOfferPostView.swift
@@ -10,15 +10,14 @@ import Moya
 
 struct SendOfferPostView: View {
     var proposeId: Int
-    let provider = MoyaProvider<SponusAPI>()
     
     @Binding var rootIsActive: Bool
     @Environment(\.presentationMode) var presentationMode
-    @State private var proposalDetail: ProposalDetailModel?
+    
     @State private var isShowingActivityView = false
     @State private var activityItems: [Any] = [URL(string: "https://example.com")!]
     
-//    @ObservedObject var proposalDetailViewModel = ProposalDetailViewModel()
+    @ObservedObject var proposalDetailViewModel = ProposalDetailViewModel()
     
     var body: some View {
         VStack(spacing: 0) {
@@ -37,11 +36,9 @@ struct SendOfferPostView: View {
                                             .opacity(phase.isIdentity ? 1.0 : 0.8)
                                             .scaleEffect(phase.isIdentity ? 1.0 : 0.8)
                                     }
-                                
                             }
                         }
                         .scrollTargetLayout()
-                        
                     }
                     .scrollTargetBehavior(.viewAligned)
                     .safeAreaPadding(.horizontal, 40.0)
@@ -51,7 +48,7 @@ struct SendOfferPostView: View {
                             ProfileView(rootIsActive: $rootIsActive)
                         } label: {
                             HStack {
-                                Text(proposalDetail?.content.proposedOrganizationName ?? "")
+                                Text(proposalDetailViewModel.proposalDetail?.proposedOrganizationName ?? "")
                                     .font(.Body10)
                                     .foregroundColor(Color.sponusPrimary)
                                 
@@ -60,7 +57,7 @@ struct SendOfferPostView: View {
                             }
                         }.padding(.top, 23)
                         
-                        Text(proposalDetail?.content.title ?? "")
+                        Text(proposalDetailViewModel.proposalDetail?.title ?? "")
                             .font(.Heading05)
                             .foregroundColor(Color.sponusBlack)
                             .padding(.top, 16)
@@ -75,7 +72,7 @@ struct SendOfferPostView: View {
                             .foregroundColor(Color.sponusGrey700)
                             .padding(.top, 24)
                         
-                        Text(proposalDetail?.content.content ?? "")
+                        Text(proposalDetailViewModel.proposalDetail?.content ?? "")
                             .multilineTextAlignment(.leading)
                             .font(.Body10)
                             .foregroundColor(.black)
@@ -86,20 +83,16 @@ struct SendOfferPostView: View {
                             .frame(maxWidth: .infinity, maxHeight: 1)
                             .padding(.top, 24)
                         
-                        SendOfferPostCell(rootIsActive: $rootIsActive, status: statusChangeToKorean(english: proposalDetail?.content.announcementDetails.status ?? ""))
+                        SendOfferPostCell(rootIsActive: $rootIsActive, status: statusChangeToKorean(english: proposalDetailViewModel.proposalDetail?.announcementDetails.status ?? ""))
                             .padding(.vertical, 16)
-                        
                     }
                     .padding(.horizontal, 20)
                 }
                 .padding(.bottom, 20)
-                
             }
             
-
             HStack(){
                 HStack(spacing: 16){
-
                     Button(action: {
                         isShowingActivityView = true
                     }) {
@@ -109,7 +102,9 @@ struct SendOfferPostView: View {
                     }.sheet(isPresented: $isShowingActivityView) {
                         ActivityView(activityItems: activityItems)
                     }
-                }.padding(.leading, 36)
+                }
+                .padding(.leading, 36)
+                
                 NavigationLink(destination: ChargerInfoView(rootIsActive: $rootIsActive)){
                     Text("담당자 정보 확인하기")
                         .font(.Body01)
@@ -117,7 +112,8 @@ struct SendOfferPostView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.top, 20)
                 }
-            }.background(Color.sponusBlack)
+            }
+            .background(Color.sponusBlack)
         }
         .gesture(
             DragGesture().onEnded { value in
@@ -135,28 +131,8 @@ struct SendOfferPostView: View {
                 .foregroundStyle(.black)
         }))
         .onAppear(){
-            fetchProposal()
-        }
-    }
-}
-
-extension SendOfferPostView {
-    func fetchProposal(){
-        provider.request(.getProposalDetail(proposeId: proposeId)) { result in
-            switch result {
-            case let .success(response):
-                do {
-                    print(proposeId)
-                    let proposalDetailResponse = try JSONDecoder().decode(ProposalDetailModel.self, from: response.data)
-                    self.proposalDetail = proposalDetailResponse
-                    //print("제안 상세 조회 \(self.proposalDetail)")
-                } catch {
-                    print("여기!!!!!")
-                    print("Error parsing response: \(error)")
-                }
-            case let .failure(error):
-                print("Network request failed: \(error)")
-            }
+            //print("보낸 Propose ID: \(proposeId)")
+            proposalDetailViewModel.fetchProposalDetail(proposeId : proposeId)
         }
     }
 }
@@ -182,7 +158,6 @@ struct SendOfferPostCell: View {
                 Text("연계 프로젝트")
                     .font(.Caption02)
                     .foregroundColor(Color.sponusGrey700)
-                
                 
                 Text("무신사 글로벌 마케팅\n연계 프로젝트")
                     .font(.Body07)

--- a/Spon-us/View/SendOffer/SendOfferView.swift
+++ b/Spon-us/View/SendOffer/SendOfferView.swift
@@ -116,63 +116,66 @@ struct SendOfferCell: View {
     @Binding var rootIsActive: Bool
     
     var sentResponse: ProposalResponse
+    @State private var selectedProposeId: Int?
     
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                ZStack {
-                    Image("musinsa")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 158, height: 158)
-                        .padding(.trailing, 20)
+        NavigationStack {
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    ZStack {
+                        Image("musinsa")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 158, height: 158)
+                            .padding(.trailing, 20)
+                        
+                        ForEach(sentResponse.proposes, id: \.self) { propose in
+                            StatusBadge(status: statusChangeToKorean(english: propose.status))
+                                .offset(x: 50.5, y: -66.5)
+                        }
+                    }
                     
-                    ForEach(sentResponse.proposes, id: \.self) { propose in
-                        StatusBadge(status: statusChangeToKorean(english: propose.status))
-                            .offset(x: 50.5, y: -66.5)
-                    }
-                }
-                
-                LazyVStack(alignment: .leading, spacing: 12) {
-                    ForEach(sentResponse.proposes, id: \.self) { propose in
-                        Text("\(changeToKorean(type: propose.announcementSummary.type) ?? "전체")")
-                            .font(.Caption02)
-                            .foregroundColor(Color.sponusGrey700)
-                        
-                        Text("\(propose.title)")
-                            .multilineTextAlignment(.leading)
-                            .font(.Body07)
-                            .foregroundColor(Color.sponusBlack)
-                        
-                        Spacer()
-                        
-                        NavigationLink(
-                            destination: SendOfferPostView(proposeId:
-                                                            propose.proposeId, rootIsActive: $rootIsActive),
-                            label: {
-                                HStack {
-                                    Text("보낸 제안서")
-                                        .padding(.leading, 5)
-                                    
-                                    Image("ic_go_blue")
-                                        .frame(width: 16, height: 16)
-                                        .padding(.leading, -3)
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(sentResponse.proposes, id: \.self) { propose in
+                            Text("\(changeToKorean(type: propose.announcementSummary.type) ?? "전체")")
+                                .font(.Caption02)
+                                .foregroundColor(Color.sponusGrey700)
+                            
+                            Text("\(propose.title)")
+                                .multilineTextAlignment(.leading)
+                                .font(.Body07)
+                                .foregroundColor(Color.sponusBlack)
+                            
+                            Spacer()
+                            
+                            NavigationLink(
+                                destination: SendOfferPostView(proposeId: propose.proposeId, rootIsActive: $rootIsActive),
+                                isActive: .constant(selectedProposeId == propose.proposeId),
+                                label: {
+                                    HStack {
+                                        Text("보낸 제안서")
+                                            .padding(.leading, 5)
+                                        
+                                        Image("ic_go_blue")
+                                            .frame(width: 16, height: 16)
+                                            .padding(.leading, -3)
+                                    }
+                                    .font(.Body10)
+                                    .foregroundStyle(Color.sponusPrimary)
+                                    .padding(.vertical, 11)
+                                    .padding(.horizontal, 10)
+                                    .overlay(
+                                        Rectangle()
+                                            .stroke(Color.sponusPrimary, lineWidth: 1)
+                                    )
                                 }
-                                .font(.Body10)
-                                .foregroundStyle(Color.sponusPrimary)
-                                .padding(.vertical, 11)
-                                .padding(.horizontal, 10)
-                                .overlay(
-                                    Rectangle()
-                                        .stroke(Color.sponusPrimary, lineWidth: 1)
-                                )
-                            }
-                        )
+                            )
+                        }
                     }
+                    .padding(.trailing, 15)
                 }
-                .padding(.trailing, 15)
+                .padding(.vertical, 16)
             }
-            .padding(.vertical, 16)
         }
     }
 }


### PR DESCRIPTION
## ✅ Task
- `SendOfferPostView.swift`에서의 extension 제외하고 `ProposalDetailViewModel()` 제대로 사용 bd3aa74