### PR TITLE
[#89] 보낸 제안서 확인 / 하단 공고 데이터 API 연동

### DIFF
--- a/Spon-us.xcodeproj/project.pbxproj
+++ b/Spon-us.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		106720022B5835FA00493354 /* SendOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106720012B5835FA00493354 /* SendOfferView.swift */; };
 		107D6E692B7A8273005B6261 /* OrganizationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107D6E682B7A8273005B6261 /* OrganizationModel.swift */; };
 		107D6E6B2B7A83AB005B6261 /* MyOrganizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107D6E6A2B7A83AB005B6261 /* MyOrganizationViewModel.swift */; };
+		109ED8682B80C61A00304695 /* SponusAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109ED8672B80C61A00304695 /* SponusAPI.swift */; };
 		109F9E282B6E692B006B7D63 /* MyTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109F9E272B6E692B006B7D63 /* MyTermsView.swift */; };
 		109F9E2A2B6E7536006B7D63 /* CouponView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109F9E292B6E7536006B7D63 /* CouponView.swift */; };
 		10C8AC612B5C340D00B40547 /* SendOfferPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C8AC602B5C340D00B40547 /* SendOfferPostView.swift */; };
@@ -119,7 +120,6 @@
 		DF5B7E922B7FA430001C009C /* PortfolioOfferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5B7E912B7FA430001C009C /* PortfolioOfferViewModel.swift */; };
 		DF5B7E942B808DF1001C009C /* EditAnnouncementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5B7E932B808DF0001C009C /* EditAnnouncementViewModel.swift */; };
 		DF5B7E962B809257001C009C /* EditAnnouncementModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5B7E952B809257001C009C /* EditAnnouncementModel.swift */; };
-		DF5B7EA62B80A59C001C009C /* SponusAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5B7EA52B80A59C001C009C /* SponusAPI.swift */; };
 		DF692B182B7E3DA700BF9B75 /* RefreshTokenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF692B172B7E3DA700BF9B75 /* RefreshTokenModel.swift */; };
 		DF692B1A2B7E970F00BF9B75 /* EditAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF692B192B7E970F00BF9B75 /* EditAnnouncementView.swift */; };
 		DF692B1C2B7EFC6F00BF9B75 /* ChangeAnnouncementStatusModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF692B1B2B7EFC6F00BF9B75 /* ChangeAnnouncementStatusModel.swift */; };
@@ -167,6 +167,7 @@
 		106720012B5835FA00493354 /* SendOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendOfferView.swift; sourceTree = "<group>"; };
 		107D6E682B7A8273005B6261 /* OrganizationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationModel.swift; sourceTree = "<group>"; };
 		107D6E6A2B7A83AB005B6261 /* MyOrganizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyOrganizationViewModel.swift; sourceTree = "<group>"; };
+		109ED8672B80C61A00304695 /* SponusAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SponusAPI.swift; sourceTree = "<group>"; };
 		109F9E272B6E692B006B7D63 /* MyTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTermsView.swift; sourceTree = "<group>"; };
 		109F9E292B6E7536006B7D63 /* CouponView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponView.swift; sourceTree = "<group>"; };
 		10C8AC602B5C340D00B40547 /* SendOfferPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendOfferPostView.swift; sourceTree = "<group>"; };
@@ -216,7 +217,6 @@
 		DF5B7E912B7FA430001C009C /* PortfolioOfferViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioOfferViewModel.swift; sourceTree = "<group>"; };
 		DF5B7E932B808DF0001C009C /* EditAnnouncementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAnnouncementViewModel.swift; sourceTree = "<group>"; };
 		DF5B7E952B809257001C009C /* EditAnnouncementModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAnnouncementModel.swift; sourceTree = "<group>"; };
-		DF5B7EA52B80A59C001C009C /* SponusAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SponusAPI.swift; path = "../../test/Spon-us/SponusAPI.swift"; sourceTree = "<group>"; };
 		DF692B172B7E3DA700BF9B75 /* RefreshTokenModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenModel.swift; sourceTree = "<group>"; };
 		DF692B192B7E970F00BF9B75 /* EditAnnouncementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAnnouncementView.swift; sourceTree = "<group>"; };
 		DF692B1B2B7EFC6F00BF9B75 /* ChangeAnnouncementStatusModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAnnouncementStatusModel.swift; sourceTree = "<group>"; };
@@ -360,7 +360,7 @@
 				3B81BCB02B622E950067E9CB /* Manager */,
 				3BFC8D192B54D43C000D6006 /* Helper */,
 				100D38942B44833500498977 /* Font */,
-				DF5B7EA52B80A59C001C009C /* SponusAPI.swift */,
+				109ED8672B80C61A00304695 /* SponusAPI.swift */,
 				100A1E352B7348DB00AAC1E8 /* Model */,
 				100D38B42B4EF18C00498977 /* View */,
 				100D38A62B44836800498977 /* Spon_usApp.swift */,
@@ -781,7 +781,7 @@
 				DF5B7E962B809257001C009C /* EditAnnouncementModel.swift in Sources */,
 				DF498F272B79B45D00ADE078 /* KeyChainManager.swift in Sources */,
 				3B36F0A12B6FEBF60000ACFB /* Utils.swift in Sources */,
-				DF5B7EA62B80A59C001C009C /* SponusAPI.swift in Sources */,
+				109ED8682B80C61A00304695 /* SponusAPI.swift in Sources */,
 				100D38A72B44836800498977 /* Spon_usApp.swift in Sources */,
 				100A1E382B734DB300AAC1E8 /* EmailModel.swift in Sources */,
 				3B36F0A82B6FEC3C0000ACFB /* PubData.swift in Sources */,

--- a/Spon-us/Model/SendOffer/ProposalDetailModel.swift
+++ b/Spon-us/Model/SendOffer/ProposalDetailModel.swift
@@ -38,6 +38,20 @@ struct AnnouncementDetails: Codable {
     let announcementImages: [AnnouncementImage]
     let status: String
     let viewCount: Int
+    
+    init(id: Int = 0, writerId: Int? = nil, title: String = "", type: String = "",
+         category: String = "", content: String = "",
+         announcementImages: [AnnouncementImage] = [], status: String = "", viewCount: Int = 0) {
+        self.id = id
+        self.writerId = writerId
+        self.title = title
+        self.type = type
+        self.category = category
+        self.content = content
+        self.announcementImages = announcementImages
+        self.status = status
+        self.viewCount = viewCount
+    }
 }
 
 struct AnnouncementImage: Codable {

--- a/Spon-us/View/SendOffer/SendOfferPostView.swift
+++ b/Spon-us/View/SendOffer/SendOfferPostView.swift
@@ -10,7 +10,6 @@ import Moya
 
 struct SendOfferPostView: View {
     var proposeId: Int
-    
     @Binding var rootIsActive: Bool
     @Environment(\.presentationMode) var presentationMode
     
@@ -43,7 +42,7 @@ struct SendOfferPostView: View {
                     .scrollTargetBehavior(.viewAligned)
                     .safeAreaPadding(.horizontal, 40.0)
                     
-                    LazyVStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: 0) {
                         NavigationLink {
                             ProfileView(rootIsActive: $rootIsActive)
                         } label: {
@@ -83,7 +82,7 @@ struct SendOfferPostView: View {
                             .frame(maxWidth: .infinity, maxHeight: 1)
                             .padding(.top, 24)
                         
-                        SendOfferPostCell(rootIsActive: $rootIsActive, status: statusChangeToKorean(english: proposalDetailViewModel.proposalDetail?.announcementDetails.status ?? ""))
+                        SendOfferPostCell(rootIsActive: $rootIsActive, status: statusChangeToKorean(english: proposalDetailViewModel.proposalDetail?.announcementDetails.status ?? ""), cellData: proposalDetailViewModel.proposalDetail?.announcementDetails ?? AnnouncementDetails())
                             .padding(.vertical, 16)
                     }
                     .padding(.horizontal, 20)
@@ -91,8 +90,8 @@ struct SendOfferPostView: View {
                 .padding(.bottom, 20)
             }
             
-            HStack(){
-                HStack(spacing: 16){
+            HStack() {
+                HStack(spacing: 16) {
                     Button(action: {
                         isShowingActivityView = true
                     }) {
@@ -105,7 +104,7 @@ struct SendOfferPostView: View {
                 }
                 .padding(.leading, 36)
                 
-                NavigationLink(destination: ChargerInfoView(rootIsActive: $rootIsActive)){
+                NavigationLink(destination: ChargerInfoView(rootIsActive: $rootIsActive)) {
                     Text("담당자 정보 확인하기")
                         .font(.Body01)
                         .foregroundColor(Color.sponusPrimaryDarkmode)
@@ -125,14 +124,13 @@ struct SendOfferPostView: View {
         .navigationTitle("보낸 제안").font(.Body01)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: CustomBackButton(), trailing: Button(action: {self.rootIsActive = false}, label: {
+        .navigationBarItems(leading: CustomBackButton(), trailing: Button(action: { self.rootIsActive = false }, label: {
             Image(.icHome)
                 .renderingMode(.template)
                 .foregroundStyle(.black)
         }))
         .onAppear(){
-            //print("보낸 Propose ID: \(proposeId)")
-            proposalDetailViewModel.fetchProposalDetail(proposeId : proposeId)
+            proposalDetailViewModel.fetchProposalDetail(proposeId: proposeId)
         }
     }
 }
@@ -140,9 +138,11 @@ struct SendOfferPostView: View {
 struct SendOfferPostCell: View {
     @Binding var rootIsActive: Bool
     var status: String
+    var cellData: AnnouncementDetails
     
     var body: some View {
         HStack(spacing: 0) {
+            /*
             ZStack {
                 Image("musinsa")
                     .resizable()
@@ -150,20 +150,29 @@ struct SendOfferPostCell: View {
                     .frame(width: 158, height: 158)
                     .padding(.trailing, 20)
                 
-                StatusBadge(status: "수락")
+                StatusBadge(status: statusChangeToKorean(english: cellData.status))
                     .offset(x: 50.5, y: -66.5)
-            }
+            }*/
             
-            LazyVStack(alignment: .leading, spacing: 12) {
-                Text("연계 프로젝트")
+            Image("musinsa")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 158, height: 158)
+                .padding(.trailing, 20)
+            
+            VStack(alignment: .leading, spacing: 12) {
+                Text("\(changeToKorean(type: cellData.type) ?? "전체")")
                     .font(.Caption02)
                     .foregroundColor(Color.sponusGrey700)
                 
-                Text("무신사 글로벌 마케팅\n연계 프로젝트")
+                Text(cellData.title)
+                    .multilineTextAlignment(.leading)
                     .font(.Body07)
                     .foregroundColor(Color.sponusBlack)
                 
-                NavigationLink(destination: CompanyPostView(rootIsActive: $rootIsActive), label: {
+                Spacer()
+                
+                NavigationLink(destination: CompanyPostView(rootIsActive: $rootIsActive)) {
                     HStack {
                         Text("공고 보기")
                             .font(.Body10)
@@ -180,9 +189,10 @@ struct SendOfferPostCell: View {
                         Rectangle()
                             .stroke(Color.sponusPrimary, lineWidth: 1)
                     )
-                })
+                }
+                .padding(.trailing, 15)
             }
-            .padding(.trailing, 15)
+            .padding(.vertical, 20)
         }
         .padding(.top, 16)
     }

--- a/Spon-us/View/SendOffer/SendOfferView.swift
+++ b/Spon-us/View/SendOffer/SendOfferView.swift
@@ -173,7 +173,7 @@ struct SendOfferCell: View {
                             )
                         }
                     }
-                    .padding(.trailing, 15)
+                    .padding(.vertical, 20)
                 }
                 .padding(.vertical, 16)
             }


### PR DESCRIPTION
## ✅ Task
- 보낸 제안서 확인 / 하단 공고 데이터 API 연동


## 🍏 시뮬레이터
| 보낸 제안서 확인 |
| ------------ |
| <img width="250px" alt="보낸 제안서 확인" src="https://github.com/spon-us/SponUs-iOS/assets/69234788/74a72007-e9e7-473d-a87f-2d8b34809f53"> |


## 💡 Issue